### PR TITLE
fix: prevent SSRF via hostnameOrAddress parameter (CWE-918, VC-53601)

### DIFF
--- a/internal/app/discovery/discovery.go
+++ b/internal/app/discovery/discovery.go
@@ -41,6 +41,17 @@ func (svc *DiscoveryService) DiscoverCertificates(c echo.Context) error {
 		return c.String(http.StatusBadRequest, fmt.Sprintf("failed to unmarshall request json: %s", err.Error()))
 	}
 
+	if req.Connection == nil {
+		return c.String(http.StatusBadRequest, "missing required field: connection")
+	}
+
+	// Validate the connection to prevent SSRF (CWE-918): an attacker could otherwise supply an
+	// arbitrary hostnameOrAddress value to redirect outbound requests to internal services.
+	if err = req.Connection.Validate(); err != nil {
+		zap.L().Error("invalid connection parameters", zap.Error(err))
+		return c.String(http.StatusBadRequest, fmt.Sprintf("invalid connection: %s", err.Error()))
+	}
+
 	var tenants TenantNames
 	if len(req.Configuration.Tenants) == 0 {
 		tenants, err = svc.getAllTenants(req.Connection)

--- a/internal/app/discovery/discovery_test.go
+++ b/internal/app/discovery/discovery_test.go
@@ -288,7 +288,7 @@ func TestDiscovery(t *testing.T) {
 				Tenants:                     "admin",
 			},
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: "avi-controller.example.com",
 				Password:          "password",
 				Username:          "user",
 			},
@@ -369,7 +369,7 @@ func TestDiscovery(t *testing.T) {
 				Tenants:                     "admin",
 			},
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: "avi-controller.example.com",
 				Password:          "password",
 				Username:          "user",
 			},
@@ -488,7 +488,7 @@ func TestDiscovery(t *testing.T) {
 				Tenants:                     "admin,Venafi,Swordfish",
 			},
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: "avi-controller.example.com",
 				Password:          "password",
 				Username:          "user",
 			},
@@ -640,7 +640,7 @@ func TestDiscovery(t *testing.T) {
 				Tenants:                     "admin,Venafi,Swordfish",
 			},
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: "avi-controller.example.com",
 				Password:          "password",
 				Username:          "user",
 			},

--- a/internal/app/domain/connection.go
+++ b/internal/app/domain/connection.go
@@ -1,9 +1,134 @@
 package domain
 
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
 // Connection represents the properties defined in the connection definition in the manifest.json file.
 type Connection struct {
 	HostnameOrAddress string `json:"hostnameOrAddress"`
 	Password          string `json:"password"`
 	Port              int    `json:"port"`
 	Username          string `json:"username"`
+}
+
+// Validate checks that the Connection fields are well-formed and safe from Server-Side Request
+// Forgery (SSRF) attacks (CWE-918).  It must be called on every inbound request before the
+// Connection is used to open a network connection.
+func (c *Connection) Validate() error {
+	if c == nil {
+		return fmt.Errorf("connection must not be nil")
+	}
+	return validateHostnameOrAddress(c.HostnameOrAddress)
+}
+
+// validateHostnameOrAddress ensures that the supplied value is a safe, well-formed hostname or
+// IP address that cannot be used to reach unintended internal destinations.
+//
+// Specifically it:
+//   - rejects empty values
+//   - tries to parse the value as an IP address first (supporting both IPv4 and IPv6 literals)
+//     and, if successful, validates the address against unsafe ranges
+//   - for non-IP values, rejects anything that contains URL structural characters
+//     (scheme separator ":/", path "/", query "?", fragment "#", userinfo "@")
+//   - rejects the hostname "localhost" (always resolves to the loopback interface)
+//   - rejects values that are not otherwise a valid RFC 952 / RFC 1123 hostname
+func validateHostnameOrAddress(hostnameOrAddress string) error {
+	if len(hostnameOrAddress) == 0 {
+		return fmt.Errorf("hostnameOrAddress must not be empty")
+	}
+
+	// Try to parse as an IP address literal first.  This must come before the URL-character
+	// check because IPv6 addresses legitimately contain colons (e.g. "2001:db8::1").
+	if ip := net.ParseIP(hostnameOrAddress); ip != nil {
+		return validateIP(ip)
+	}
+
+	// Not an IP address.  Now reject anything that looks like a URL or contains characters
+	// that have no place in a bare hostname.  This blocks inputs such as:
+	//   http://169.254.169.254/latest/meta-data/
+	//   169.254.169.254/latest/meta-data/
+	//   user@host
+	//   host?query=value
+	if strings.ContainsAny(hostnameOrAddress, "/:?#@") {
+		return fmt.Errorf(
+			"hostnameOrAddress %q must be a plain hostname or IP address, not a URL",
+			hostnameOrAddress,
+		)
+	}
+
+	// Validate it as a hostname per RFC 952 / RFC 1123.
+	if !isValidHostname(hostnameOrAddress) {
+		return fmt.Errorf(
+			"hostnameOrAddress %q is not a valid hostname or IP address",
+			hostnameOrAddress,
+		)
+	}
+
+	// Reject "localhost" by name: it always resolves to the loopback interface and is never a
+	// legitimate VMware AVI controller address.
+	if strings.EqualFold(hostnameOrAddress, "localhost") {
+		return fmt.Errorf(
+			"hostnameOrAddress %q resolves to a loopback address and must not be used",
+			hostnameOrAddress,
+		)
+	}
+
+	return nil
+}
+
+// validateIP returns an error when the provided IP address falls within a range that should
+// never host a VMware AVI controller and could be exploited for SSRF.
+func validateIP(ip net.IP) error {
+	switch {
+	case ip.IsLoopback():
+		// Covers 127.0.0.0/8 and ::1.
+		return fmt.Errorf("hostnameOrAddress %q must not be a loopback address", ip.String())
+	case ip.IsLinkLocalUnicast():
+		// Covers 169.254.0.0/16 (includes the AWS/GCP/Azure instance-metadata endpoint
+		// 169.254.169.254) and fe80::/10.
+		return fmt.Errorf("hostnameOrAddress %q must not be a link-local address", ip.String())
+	case ip.IsLinkLocalMulticast():
+		return fmt.Errorf("hostnameOrAddress %q must not be a link-local multicast address", ip.String())
+	case ip.IsUnspecified():
+		// Covers 0.0.0.0 and ::.
+		return fmt.Errorf("hostnameOrAddress %q must not be an unspecified address", ip.String())
+	case ip.IsMulticast():
+		return fmt.Errorf("hostnameOrAddress %q must not be a multicast address", ip.String())
+	}
+	return nil
+}
+
+// isValidHostname returns true when hostname conforms to RFC 952 / RFC 1123 naming rules:
+//   - total length 1–253 characters
+//   - one or more dot-separated labels, each 1–63 characters
+//   - each label contains only ASCII letters, digits, and hyphens
+//   - no label starts or ends with a hyphen
+func isValidHostname(hostname string) bool {
+	const maxHostnameLen = 253
+	const maxLabelLen = 63
+
+	if len(hostname) == 0 || len(hostname) > maxHostnameLen {
+		return false
+	}
+
+	labels := strings.Split(hostname, ".")
+	for _, label := range labels {
+		if len(label) == 0 || len(label) > maxLabelLen {
+			return false
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, ch := range label {
+			if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+				(ch >= '0' && ch <= '9') || ch == '-') {
+				return false
+			}
+		}
+	}
+
+	return true
 }

--- a/internal/app/domain/connection_test.go
+++ b/internal/app/domain/connection_test.go
@@ -1,0 +1,165 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid_hostname", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "avi-controller.example.com"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid_hostname_single_label", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "avi-controller"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid_ipv4_public", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "203.0.113.10"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid_ipv4_private_rfc1918", func(t *testing.T) {
+		// VMware AVI controllers are legitimately deployed on RFC 1918 private networks.
+		c := &Connection{HostnameOrAddress: "10.0.0.1"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid_ipv4_private_172_16", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "172.16.0.1"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid_ipv4_private_192_168", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "192.168.1.100"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid_ipv6_global_unicast", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "2001:db8::1"}
+		require.NoError(t, c.Validate())
+	})
+
+	// --- rejection cases ---
+
+	t.Run("reject_nil_connection", func(t *testing.T) {
+		var c *Connection
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_empty_hostnameOrAddress", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: ""}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_url_with_scheme", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "http://169.254.169.254/latest/meta-data/"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_url_with_path_only", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "169.254.169.254/latest/meta-data/"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_url_with_query", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "avi-controller.example.com?param=value"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_url_with_fragment", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "avi-controller.example.com#fragment"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_url_with_userinfo", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "user@avi-controller.example.com"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv4_loopback", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "127.0.0.1"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv4_loopback_other", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "127.100.200.1"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv4_link_local_metadata", func(t *testing.T) {
+		// Cloud instance-metadata endpoint used in SSRF attacks.
+		c := &Connection{HostnameOrAddress: "169.254.169.254"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv4_link_local_other", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "169.254.0.1"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv4_unspecified", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "0.0.0.0"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv4_multicast", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "224.0.0.1"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv6_loopback", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "::1"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv6_unspecified", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "::"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_ipv6_link_local", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "fe80::1"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_localhost_lowercase", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "localhost"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_localhost_mixed_case", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "LOCALHOST"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_invalid_hostname_leading_hyphen", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "-bad.example.com"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_invalid_hostname_trailing_hyphen", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "bad-.example.com"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_invalid_hostname_underscore", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "bad_host.example.com"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_invalid_hostname_space", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "bad host.example.com"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("reject_invalid_hostname_empty_label", func(t *testing.T) {
+		c := &Connection{HostnameOrAddress: "bad..example.com"}
+		require.Error(t, c.Validate())
+	})
+}

--- a/internal/app/vmware-avi/configure.go
+++ b/internal/app/vmware-avi/configure.go
@@ -37,6 +37,17 @@ func (svc *WebhookServiceImpl) HandleConfigureInstallationEndpoint(c echo.Contex
 		return c.String(http.StatusBadRequest, fmt.Sprintf("failed to unmarshall json: %s", err.Error()))
 	}
 
+	if req.Connection == nil {
+		return c.String(http.StatusBadRequest, "missing required field: connection")
+	}
+
+	// Validate the connection to prevent SSRF (CWE-918): an attacker could otherwise supply an
+	// arbitrary hostnameOrAddress value to redirect outbound requests to internal services.
+	if err := req.Connection.Validate(); err != nil {
+		zap.L().Error("invalid connection parameters", zap.Error(err))
+		return c.String(http.StatusBadRequest, fmt.Sprintf("invalid connection: %s", err.Error()))
+	}
+
 	var err error
 
 	client := svc.ClientServices.NewClient(req.Connection, req.Keystore.Tenant)

--- a/internal/app/vmware-avi/configure_test.go
+++ b/internal/app/vmware-avi/configure_test.go
@@ -36,7 +36,7 @@ func TestConfigure(t *testing.T) {
 
 		raw, err = json.Marshal(&ConfigureInstallationEndpointRequest{
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: aviTestHost,
 				Password:          "password",
 				Port:              443,
 				Username:          "user",
@@ -85,7 +85,7 @@ func TestConfigure(t *testing.T) {
 			})
 
 		kacn := "installation.test.io"
-		kacURL := "https://localhost/api/virtualservice/" + kacn
+		kacURL := "https://avi-controller.example.com/api/virtualservice/" + kacn
 
 		mockClientServices.EXPECT().
 			GetSSLKeyAndCertificateByName(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/internal/app/vmware-avi/install.go
+++ b/internal/app/vmware-avi/install.go
@@ -42,6 +42,17 @@ func (svc *WebhookServiceImpl) HandleInstallCertificateBundle(c echo.Context) er
 		return c.String(http.StatusBadRequest, fmt.Sprintf("failed to unmarshall json: %s", err.Error()))
 	}
 
+	if req.Connection == nil {
+		return c.String(http.StatusBadRequest, "missing required field: connection")
+	}
+
+	// Validate the connection to prevent SSRF (CWE-918): an attacker could otherwise supply an
+	// arbitrary hostnameOrAddress value to redirect outbound requests to internal services.
+	if err := req.Connection.Validate(); err != nil {
+		zap.L().Error("invalid connection parameters", zap.Error(err))
+		return c.String(http.StatusBadRequest, fmt.Sprintf("invalid connection: %s", err.Error()))
+	}
+
 	var err error
 
 	client := svc.ClientServices.NewClient(req.Connection, req.InstallationKeystore.Tenant)

--- a/internal/app/vmware-avi/install_test.go
+++ b/internal/app/vmware-avi/install_test.go
@@ -215,7 +215,7 @@ func TestInstall(t *testing.T) {
 
 		raw, err = json.Marshal(&InstallCertificateBundleRequest{
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: aviTestHost,
 				Password:          "password",
 				Port:              443,
 				Username:          "user",

--- a/internal/app/vmware-avi/test_connection.go
+++ b/internal/app/vmware-avi/test_connection.go
@@ -30,6 +30,17 @@ func (svc *WebhookServiceImpl) HandleTestConnection(c echo.Context) error {
 		return c.String(http.StatusBadRequest, fmt.Sprintf("failed to unmarshall json: %s", err.Error()))
 	}
 
+	if req.Connection == nil {
+		return c.String(http.StatusBadRequest, "missing required field: connection")
+	}
+
+	// Validate the connection to prevent SSRF (CWE-918): an attacker could otherwise supply an
+	// arbitrary hostnameOrAddress value to redirect outbound requests to internal services.
+	if err = req.Connection.Validate(); err != nil {
+		zap.L().Error("invalid connection parameters", zap.Error(err))
+		return c.String(http.StatusBadRequest, fmt.Sprintf("invalid connection: %s", err.Error()))
+	}
+
 	res := TestConnectionResponse{
 		Result: false,
 	}

--- a/internal/app/vmware-avi/test_connection_test.go
+++ b/internal/app/vmware-avi/test_connection_test.go
@@ -15,6 +15,11 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// aviTestHost is a representative VMware AVI controller hostname used in unit tests.
+// It intentionally avoids "localhost" and loopback/link-local addresses so that the
+// SSRF input-validation added by CWE-918 does not reject it.
+const aviTestHost = "avi-controller.example.com"
+
 func TestConnectionTest(t *testing.T) {
 	var err error
 
@@ -49,7 +54,7 @@ func TestConnectionTest(t *testing.T) {
 
 		raw, err = json.Marshal(&TestConnectionRequest{
 			Connection: &domain.Connection{
-				HostnameOrAddress: "localhost",
+				HostnameOrAddress: aviTestHost,
 				Password:          "password",
 				Port:              443,
 				Username:          "user",
@@ -79,6 +84,115 @@ func TestConnectionTest(t *testing.T) {
 		err = json.Unmarshal([]byte(body), tcr)
 		require.NoError(t, err)
 		require.True(t, tcr.Result)
+	})
+
+	t.Run("reject_ssrf_loopback_ip", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// No mock expectations: the handler must reject the request before touching client services.
+		mockClientServices := mocks.NewMockClientServices(ctrl)
+		whService := NewWebhookService(mockClientServices, nil)
+
+		var raw []byte
+		raw, err = json.Marshal(&TestConnectionRequest{
+			Connection: &domain.Connection{
+				HostnameOrAddress: "127.0.0.1",
+				Password:          "password",
+				Port:              443,
+				Username:          "user",
+			},
+		})
+		require.NoError(t, err)
+
+		recorder, ctx := setupPost(e, "/v1/testconnection", bytes.NewReader(raw))
+		err = whService.HandleTestConnection(ctx)
+		require.NoError(t, err) // handler returns HTTP error, not a Go error
+
+		response := recorder.Result() //nolint:bodyclose
+		defer func() { _ = response.Body.Close() }()
+		require.Equal(t, http.StatusBadRequest, response.StatusCode)
+	})
+
+	t.Run("reject_ssrf_metadata_ip", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClientServices := mocks.NewMockClientServices(ctrl)
+		whService := NewWebhookService(mockClientServices, nil)
+
+		var raw []byte
+		raw, err = json.Marshal(&TestConnectionRequest{
+			Connection: &domain.Connection{
+				HostnameOrAddress: "169.254.169.254",
+				Password:          "password",
+				Port:              443,
+				Username:          "user",
+			},
+		})
+		require.NoError(t, err)
+
+		recorder, ctx := setupPost(e, "/v1/testconnection", bytes.NewReader(raw))
+		err = whService.HandleTestConnection(ctx)
+		require.NoError(t, err)
+
+		response := recorder.Result() //nolint:bodyclose
+		defer func() { _ = response.Body.Close() }()
+		require.Equal(t, http.StatusBadRequest, response.StatusCode)
+	})
+
+	t.Run("reject_ssrf_url_input", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClientServices := mocks.NewMockClientServices(ctrl)
+		whService := NewWebhookService(mockClientServices, nil)
+
+		var raw []byte
+		raw, err = json.Marshal(&TestConnectionRequest{
+			Connection: &domain.Connection{
+				HostnameOrAddress: "http://169.254.169.254/latest/meta-data/",
+				Password:          "password",
+				Port:              443,
+				Username:          "user",
+			},
+		})
+		require.NoError(t, err)
+
+		recorder, ctx := setupPost(e, "/v1/testconnection", bytes.NewReader(raw))
+		err = whService.HandleTestConnection(ctx)
+		require.NoError(t, err)
+
+		response := recorder.Result() //nolint:bodyclose
+		defer func() { _ = response.Body.Close() }()
+		require.Equal(t, http.StatusBadRequest, response.StatusCode)
+	})
+
+	t.Run("reject_ssrf_localhost", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClientServices := mocks.NewMockClientServices(ctrl)
+		whService := NewWebhookService(mockClientServices, nil)
+
+		var raw []byte
+		raw, err = json.Marshal(&TestConnectionRequest{
+			Connection: &domain.Connection{
+				HostnameOrAddress: "localhost",
+				Password:          "password",
+				Port:              443,
+				Username:          "user",
+			},
+		})
+		require.NoError(t, err)
+
+		recorder, ctx := setupPost(e, "/v1/testconnection", bytes.NewReader(raw))
+		err = whService.HandleTestConnection(ctx)
+		require.NoError(t, err)
+
+		response := recorder.Result() //nolint:bodyclose
+		defer func() { _ = response.Body.Close() }()
+		require.Equal(t, http.StatusBadRequest, response.StatusCode)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes a high-severity Server-Side Request Forgery vulnerability (CWE-918) in the VMware AVI connector where the attacker-controlled `hostnameOrAddress` field was forwarded directly to `clients.NewAviClient()` across all four request handlers without any validation.

Refs: VC-53601 / Epic VC-53597

---

## Root Cause

`domain.Connection.HostnameOrAddress` is deserialized from the JSON request body and used verbatim as the target host for every outbound VMware AVI connection. No sanitisation or validation was performed, meaning an attacker who can send requests to the connector can supply:

| Attack input | Reaches |
|---|---|
| `169.254.169.254` | Cloud instance-metadata (AWS/GCP/Azure) |
| `http://169.254.169.254/latest/meta-data/` | Same, via URL injection |
| `127.0.0.1` / `localhost` | Loopback services on the connector host |
| `::1` | IPv6 loopback |
| `fe80::1` | Link-local services |
| `user@internal-host` | Arbitrary host via userinfo injection |

All four entry-point handlers were affected:
- `HandleTestConnection`
- `HandleConfigureInstallationEndpoint`
- `HandleInstallCertificateBundle`
- `DiscoverCertificates`

---

## Fix

### `internal/app/domain/connection.go`
Added `Connection.Validate()` and a `validateHostnameOrAddress()` helper that enforces:

1. **Non-empty** — value must be provided.
2. **IP-first parsing** — `net.ParseIP` is tried before any character checks so that IPv6 literals (which legitimately contain `:`) are handled correctly.
3. **IP range blocking** — loopback (`127.0.0.0/8`, `::1`), link-local / cloud-metadata (`169.254.0.0/16`, `fe80::/10`), unspecified (`0.0.0.0`, `::`), and multicast ranges are all rejected.
4. **URL-character rejection** — after the IP path, values containing `/ : ? # @` are rejected, blocking URL-format injection such as `http://internal/path`.
5. **Hostname format** — remaining values are validated against RFC 952/RFC 1123 rules (labels of 1–63 alphanumeric/hyphen characters, total ≤ 253 characters, no leading/trailing hyphens).
6. **`localhost` by name** — always resolves to loopback; rejected explicitly.

> **Note:** Private RFC 1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) are intentionally **not** blocked — VMware AVI controllers are routinely deployed on private networks and these are legitimate connector targets.

### All four request handlers
Each handler now calls `req.Connection.Validate()` immediately after `c.Bind()` and before any interaction with `ClientServices`, returning `400 Bad Request` on failure.

### Tests
- **`internal/app/domain/connection_test.go`** (new): 25 test cases covering valid inputs (private IPs, public IPs, well-formed hostnames, IPv6 global unicast) and all rejection cases (loopback, link-local/metadata, unspecified, multicast, URL-format, `localhost`, malformed hostnames).
- **`test_connection_test.go`**: updated happy-path hostname from `"localhost"` → `"avi-controller.example.com"`; added four SSRF rejection tests covering `127.0.0.1`, `169.254.169.254`, a URL-format input, and `localhost`.
- **`configure_test.go`**, **`install_test.go`**, **`discovery_test.go`**: hostname updated to `"avi-controller.example.com"`.

All existing tests continue to pass (`go test ./...`, `go vet ./...` — clean).