### PR TITLE
fix: fail-closed on JWE decryption failure (CWE-636 / VC-53601)

### DIFF
--- a/internal/handler/web/web.go
+++ b/internal/handler/web/web.go
@@ -4,10 +4,11 @@ package web
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -16,6 +17,8 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/square/go-jose.v2"
 )
+
+const payloadEncryptionKeyPath = "/keys/payload-encryption-key.pem"
 
 // WebhookService interfaces for the connector operation functions
 type WebhookService interface {
@@ -51,14 +54,22 @@ func ConfigureHTTPServers(lifecycle fx.Lifecycle, shutdowner fx.Shutdowner) (*ec
 	return e, nil
 }
 
-// RegisterHandlers adds the method handlers for the supported routes
+// RegisterHandlers adds the method handlers for the supported routes.
+// It returns an error if payload encryption middleware cannot be configured,
+// which causes fx to abort application start-up (fail-closed per CWE-636).
 func RegisterHandlers(e *echo.Echo, whService WebhookService) error {
 	e.GET("/healthz", func(c echo.Context) error {
 		return c.String(http.StatusOK, "OK")
 	})
 
 	g := e.Group("/v1")
-	addPayloadEncryptionMiddleware(g)
+
+	// Fail-closed (CWE-636): propagate any key-loading error so that fx aborts
+	// start-up. No route must ever be reachable without functioning decryption.
+	if err := addPayloadEncryptionMiddleware(g); err != nil {
+		return fmt.Errorf("failed to configure payload encryption middleware: %w", err)
+	}
+
 	g.POST("/testconnection", whService.HandleTestConnection)
 	g.POST("/gettargetconfiguration", whService.HandleGetTargetConfiguration)
 	g.POST("/configureinstallationendpoint", whService.HandleConfigureInstallationEndpoint)
@@ -68,40 +79,77 @@ func RegisterHandlers(e *echo.Echo, whService WebhookService) error {
 	return nil
 }
 
-func addPayloadEncryptionMiddleware(g *echo.Group) {
-	privateKeyPemData, err := os.ReadFile("/keys/payload-encryption-key.pem")
+// addPayloadEncryptionMiddleware loads the private key from the well-known path
+// and registers JWE decryption middleware on the route group.
+func addPayloadEncryptionMiddleware(g *echo.Group) error {
+	return addPayloadEncryptionMiddlewareFromPath(g, payloadEncryptionKeyPath)
+}
+
+// addPayloadEncryptionMiddlewareFromPath registers JWE decryption middleware on
+// the given route group using the RSA private key at keyPath.
+//
+// SECURITY: this function MUST return an error on any key-loading failure.
+// Callers treat that error as fatal and must not serve the route group without
+// the middleware in place (fail-closed per CWE-636: Not Failing Securely).
+func addPayloadEncryptionMiddlewareFromPath(g *echo.Group, keyPath string) error {
+	pk, err := loadRSAPrivateKey(keyPath)
 	if err != nil {
-		zap.L().Error("payload encryption key not found or readable", zap.Error(err))
-		return
+		// Return the error — do NOT fall through and leave the group unprotected.
+		return err
 	}
-	p, _ := pem.Decode(privateKeyPemData)
-	if p == nil {
-		zap.L().Error("payload encryption key not in PEM format")
-		return
-	}
-	pk, err := x509.ParsePKCS1PrivateKey(p.Bytes)
-	if err != nil {
-		zap.L().Error("payload encryption key not properly encoded", zap.Error(err))
-		return
-	}
+
 	zap.L().Info("adding payload encryption middleware")
-	g.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+	g.Use(jweDecryptMiddleware(pk))
+	return nil
+}
+
+// loadRSAPrivateKey reads and parses a PKCS#1 RSA private key from a PEM file.
+func loadRSAPrivateKey(keyPath string) (*rsa.PrivateKey, error) {
+	pemData, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("payload encryption key not found or readable: %w", err)
+	}
+
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("payload encryption key not in PEM format")
+	}
+
+	pk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("payload encryption key not properly encoded: %w", err)
+	}
+
+	return pk, nil
+}
+
+// jweDecryptMiddleware returns an Echo middleware that decrypts JWE-encoded
+// request bodies before passing them to the next handler.
+// Any failure to parse or decrypt the token results in an HTTP error response,
+// ensuring that JWE decryption failure is always fail-closed.
+func jweDecryptMiddleware(pk *rsa.PrivateKey) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			req := c.Request()
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				return err
 			}
+
 			object, err := jose.ParseEncrypted(string(body))
 			if err != nil {
-				return err
+				// Body is not a valid JWE token — reject, never pass to handler.
+				return echo.NewHTTPError(http.StatusBadRequest, "request body is not a valid JWE token")
 			}
+
 			decrypted, err := object.Decrypt(pk)
 			if err != nil {
-				return err
+				// Decryption failure must be fail-closed: reject the request.
+				return echo.NewHTTPError(http.StatusUnauthorized, "JWE decryption failed")
 			}
+
 			req.Body = io.NopCloser(bytes.NewReader(decrypted))
 			return next(c)
 		}
-	})
+	}
 }

--- a/internal/handler/web/web_test.go
+++ b/internal/handler/web/web_test.go
@@ -1,0 +1,181 @@
+package web
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// writeRSAKeyPEMFile generates a fresh RSA-2048 key, writes it to a temp file
+// in PKCS#1 PEM format, and returns the file path together with the private key.
+func writeRSAKeyPEMFile(t *testing.T) (keyPath string, pk *rsa.PrivateKey) {
+	t.Helper()
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pemBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(pk),
+	}
+	dir := t.TempDir()
+	keyPath = filepath.Join(dir, "payload-encryption-key.pem")
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(pemBlock), 0600))
+	return keyPath, pk
+}
+
+// encryptJWE encrypts plaintext with the given RSA public key and returns a
+// compact-serialised JWE string.
+func encryptJWE(t *testing.T, pub *rsa.PublicKey, plaintext []byte) string {
+	t.Helper()
+	enc, err := jose.NewEncrypter(
+		jose.A256GCM,
+		jose.Recipient{Algorithm: jose.RSA_OAEP, Key: pub},
+		nil,
+	)
+	require.NoError(t, err)
+	obj, err := enc.Encrypt(plaintext)
+	require.NoError(t, err)
+	s, err := obj.CompactSerialize()
+	require.NoError(t, err)
+	return s
+}
+
+// newEchoWithMiddleware returns an *echo.Echo whose /v1 group has JWE
+// decryption middleware loaded from keyPath, and a POST /v1/test handler that
+// returns the (decrypted) request body as the response body.
+func newEchoWithMiddleware(t *testing.T, keyPath string) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	g := e.Group("/v1")
+	require.NoError(t, addPayloadEncryptionMiddlewareFromPath(g, keyPath))
+	g.POST("/test", func(c echo.Context) error {
+		b, err := io.ReadAll(c.Request().Body)
+		if err != nil {
+			return err
+		}
+		return c.String(http.StatusOK, string(b))
+	})
+	return e
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed tests (CWE-636)
+// ---------------------------------------------------------------------------
+
+// TestAddPayloadEncryptionMiddleware_MissingKey asserts that a missing key file
+// causes an error rather than silently leaving the route group unprotected.
+func TestAddPayloadEncryptionMiddleware_MissingKey(t *testing.T) {
+	g := echo.New().Group("/v1")
+	err := addPayloadEncryptionMiddlewareFromPath(g, "/nonexistent/path/key.pem")
+	require.Error(t, err,
+		"missing key file must return an error (fail-closed, CWE-636)")
+}
+
+// TestAddPayloadEncryptionMiddleware_InvalidPEM asserts fail-closed when the
+// key file exists but its content is not valid PEM.
+func TestAddPayloadEncryptionMiddleware_InvalidPEM(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(path, []byte("this is not pem data"), 0600))
+
+	g := echo.New().Group("/v1")
+	err := addPayloadEncryptionMiddlewareFromPath(g, path)
+	require.Error(t, err,
+		"invalid PEM content must return an error (fail-closed, CWE-636)")
+}
+
+// TestAddPayloadEncryptionMiddleware_InvalidKey asserts fail-closed when the
+// PEM frame is valid but the contained bytes are not a parseable RSA key.
+func TestAddPayloadEncryptionMiddleware_InvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem")
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("not-a-real-key")}
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(block), 0600))
+
+	g := echo.New().Group("/v1")
+	err := addPayloadEncryptionMiddlewareFromPath(g, path)
+	require.Error(t, err,
+		"malformed RSA key bytes must return an error (fail-closed, CWE-636)")
+}
+
+// TestRegisterHandlers_FailsWithoutKey verifies that RegisterHandlers returns a
+// non-nil error when the well-known key file is absent, so that fx aborts
+// application start-up instead of serving unprotected routes.
+func TestRegisterHandlers_FailsWithoutKey(t *testing.T) {
+	e := echo.New()
+	err := RegisterHandlers(e, nil)
+	require.Error(t, err,
+		"RegisterHandlers must fail when encryption key is missing (fail-closed, CWE-636)")
+}
+
+// ---------------------------------------------------------------------------
+// Runtime middleware tests
+// ---------------------------------------------------------------------------
+
+// TestMiddleware_RejectsPlaintext verifies that a plain-text (non-JWE) body is
+// rejected with HTTP 400 and never forwarded to the handler.
+func TestMiddleware_RejectsPlaintext(t *testing.T) {
+	keyPath, _ := writeRSAKeyPEMFile(t)
+	e := newEchoWithMiddleware(t, keyPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader("not-a-jwe-token"))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"plain-text body must be rejected with 400 (fail-closed)")
+}
+
+// TestMiddleware_RejectsWrongKey verifies that a structurally valid JWE
+// encrypted with a *different* key is rejected with HTTP 401.
+func TestMiddleware_RejectsWrongKey(t *testing.T) {
+	serverKeyPath, _ := writeRSAKeyPEMFile(t)
+
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	token := encryptJWE(t, &otherKey.PublicKey, []byte(`{"field":"value"}`))
+
+	e := newEchoWithMiddleware(t, serverKeyPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(token))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"JWE encrypted with the wrong key must be rejected with 401 (fail-closed)")
+}
+
+// TestMiddleware_AcceptsValidJWE verifies the happy path: a request correctly
+// encrypted with the server's public key is decrypted and forwarded to the handler.
+func TestMiddleware_AcceptsValidJWE(t *testing.T) {
+	keyPath, pk := writeRSAKeyPEMFile(t)
+	payload := []byte(`{"hello":"world"}`)
+	token := encryptJWE(t, &pk.PublicKey, payload)
+
+	e := newEchoWithMiddleware(t, keyPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(token))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "valid JWE must be accepted")
+	assert.Equal(t, string(payload), rec.Body.String(),
+		"handler must receive the decrypted plaintext payload")
+}


### PR DESCRIPTION
## Summary

Closes finding **web-CWE-636-jwe-fail-open** (CWE-636 — Not Failing Securely, Severity: High).
Part of story **VC-53601** / epic **VC-53597**.

---

## Root cause

`addPayloadEncryptionMiddleware` in `internal/handler/web/web.go` had three early-return paths — triggered when the private key file is missing, not valid PEM, or not a parseable RSA key — that logged an error and **returned without registering any middleware**:

```go
// BEFORE (vulnerable)
func addPayloadEncryptionMiddleware(g *echo.Group) {
    privateKeyPemData, err := os.ReadFile("/keys/payload-encryption-key.pem")
    if err != nil {
        zap.L().Error("payload encryption key not found or readable", zap.Error(err))
        return          // ← no middleware registered; group is left wide open
    }
    p, _ := pem.Decode(privateKeyPemData)
    if p == nil {
        zap.L().Error("payload encryption key not in PEM format")
        return          // ← same
    }
    pk, err := x509.ParsePKCS1PrivateKey(p.Bytes)
    if err != nil {
        zap.L().Error("payload encryption key not properly encoded", zap.Error(err))
        return          // ← same
    }
    g.Use(...)
}
```

Because `RegisterHandlers` discarded the (non-existent) return value, every `/v1/*` endpoint was reachable **without any JWE token** whenever the key could not be loaded. An attacker could send a plain-text or otherwise malformed request and have it processed as if it had been properly authenticated and decrypted (classic fail-open / CWE-636).

A secondary issue: when the key *was* loaded, parse failures during per-request decryption returned raw `error` values to Echo's default error handler, which produced generic 500 responses rather than the semantically correct 400/401, and leaked internal error detail.

---

## Changes

### `internal/handler/web/web.go`

| What | How |
|---|---|
| **Fail-closed at startup** | `addPayloadEncryptionMiddleware` now returns `error`. All three key-loading failure paths `return nil, fmt.Errorf(…)` instead of silently returning. |
| **Propagate to fx** | `RegisterHandlers` checks the error and returns it; `fx.Invoke` then aborts application start-up so no route is ever reachable without a functioning decryption layer. |
| **Testability** | Extract `addPayloadEncryptionMiddlewareFromPath(g, keyPath)` (injectable path) and `loadRSAPrivateKey(keyPath)` so the key-loading logic can be unit-tested without filesystem side-effects. |
| **Explicit HTTP errors on per-request failure** | `jweDecryptMiddleware` (extracted) now returns `echo.NewHTTPError(400, …)` for invalid JWE syntax and `echo.NewHTTPError(401, …)` for decryption failure, rather than passing raw errors to Echo's default handler. |
| **Housekeeping** | Replace deprecated `ioutil.ReadAll` with `io.ReadAll`. Extract the key path as a named constant. |

### `internal/handler/web/web_test.go` *(new file)*

7 tests covering every fail-closed path and the happy-path flow:

| Test | Asserts |
|---|---|
| `TestAddPayloadEncryptionMiddleware_MissingKey` | Error returned when key file is absent |
| `TestAddPayloadEncryptionMiddleware_InvalidPEM` | Error returned when file is not valid PEM |
| `TestAddPayloadEncryptionMiddleware_InvalidKey` | Error returned when PEM block contains non-RSA bytes |
| `TestRegisterHandlers_FailsWithoutKey` | `RegisterHandlers` propagates error, preventing start-up |
| `TestMiddleware_RejectsPlaintext` | Plain-text body → HTTP 400 |
| `TestMiddleware_RejectsWrongKey` | JWE encrypted with wrong key → HTTP 401 |
| `TestMiddleware_AcceptsValidJWE` | Correctly encrypted request → handler receives plaintext payload |

---

## Before / After

```
# Before: missing key → silent no-op, all /v1 routes open
WARN  payload encryption key not found or readable  ...
POST /v1/testconnection  → 200 OK   ← attacker wins

# After: missing key → fatal start-up error, no routes served
ERROR failed to configure payload encryption middleware: ...
[fx] ERROR  Failed to start  ← server never binds
```