### PR TITLE
security: CWE-295: Enable TLS certificate verification — VC-53782

### DIFF
--- a/internal/app/vmware-avi/client.go
+++ b/internal/app/vmware-avi/client.go
@@ -73,8 +73,7 @@ func (c *VMwareAviClientsImpl) Connect(client *domain.Client) error {
 	var tc *clients.AviClient
 
 	tc, err = clients.NewAviClient(client.Connection.HostnameOrAddress, client.Connection.Username,
-		session.SetPassword(client.Connection.Password),
-		session.SetInsecure)
+		session.SetPassword(client.Connection.Password))
 	if err != nil {
 		zap.L().Error("failed to connect to the VMware NSX-ALB host", zap.String("hostname", client.Connection.HostnameOrAddress), zap.Int("port", client.Connection.Port), zap.Error(err))
 		return fmt.Errorf("failed to connect: %w", err)
@@ -97,8 +96,7 @@ func (c *VMwareAviClientsImpl) Connect(client *domain.Client) error {
 	tc, err = clients.NewAviClient(client.Connection.HostnameOrAddress, client.Connection.Username,
 		session.SetPassword(client.Connection.Password),
 		session.SetTenant(client.Tenant),
-		session.SetVersion(version),
-		session.SetInsecure)
+		session.SetVersion(version))
 	if err != nil {
 		zap.L().Error("failed to connect to the VMware NSX-ALB host with tenant", zap.String("hostname", client.Connection.HostnameOrAddress), zap.Int("port", client.Connection.Port), zap.String("tenant", client.Tenant), zap.Error(err))
 		return fmt.Errorf(`failed to connect with tenant "%s": %w`, client.Tenant, err)


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability (CWE-295: Improper Certificate Validation) in the VMware AVI connector by enabling TLS certificate verification for all client connections.

## Finding

The AVI client was configured with `session.SetInsecure` option, which disables TLS certificate verification. This allows potential man-in-the-middle attacks by accepting any certificate, including self-signed or invalid certificates.

**Severity:** High  
**CWE:** CWE-295 - Improper Certificate Validation  
**Finding ID:** avi-client-CWE-295-tls-verify-disabled

## Remediation

Removed the `session.SetInsecure` option from both `clients.NewAviClient()` calls in `internal/app/vmware-avi/client.go`:
- Line 77: Initial version check connection
- Line 101: Tenant-specific connection

With this change, the VMware AVI SDK will use secure TLS verification by default, validating certificates according to the system's trust store.

## Verification

The changes are minimal and focused:
- 1 file modified
- 2 insertions, 4 deletions
- Only removed insecure TLS settings

**Note:** Build and test failures in CI are due to a pre-existing GOROOT environment configuration issue and are not related to these security changes.