### PR TITLE
security: CWE-636: Fix fail-open JWE decryption — VC-53785

### DIFF
--- a/internal/handler/web/web.go
+++ b/internal/handler/web/web.go
@@ -58,7 +58,9 @@ func RegisterHandlers(e *echo.Echo, whService WebhookService) error {
 	})
 
 	g := e.Group("/v1")
-	addPayloadEncryptionMiddleware(g)
+	if err := addPayloadEncryptionMiddleware(g); err != nil {
+		return err
+	}
 	g.POST("/testconnection", whService.HandleTestConnection)
 	g.POST("/gettargetconfiguration", whService.HandleGetTargetConfiguration)
 	g.POST("/configureinstallationendpoint", whService.HandleConfigureInstallationEndpoint)
@@ -68,21 +70,21 @@ func RegisterHandlers(e *echo.Echo, whService WebhookService) error {
 	return nil
 }
 
-func addPayloadEncryptionMiddleware(g *echo.Group) {
+func addPayloadEncryptionMiddleware(g *echo.Group) error {
 	privateKeyPemData, err := os.ReadFile("/keys/payload-encryption-key.pem")
 	if err != nil {
 		zap.L().Error("payload encryption key not found or readable", zap.Error(err))
-		return
+		return err
 	}
 	p, _ := pem.Decode(privateKeyPemData)
 	if p == nil {
 		zap.L().Error("payload encryption key not in PEM format")
-		return
+		return echo.NewHTTPError(http.StatusInternalServerError, "payload encryption key not in PEM format")
 	}
 	pk, err := x509.ParsePKCS1PrivateKey(p.Bytes)
 	if err != nil {
 		zap.L().Error("payload encryption key not properly encoded", zap.Error(err))
-		return
+		return err
 	}
 	zap.L().Info("adding payload encryption middleware")
 	g.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -104,4 +106,5 @@ func addPayloadEncryptionMiddleware(g *echo.Group) {
 			return next(c)
 		}
 	})
+	return nil
 }


### PR DESCRIPTION
## Summary

Fix CWE-636 fail-open vulnerability in JWE payload encryption middleware by ensuring server fails to start if encryption cannot be properly configured.

## Finding

**CWE-636**: Fail-open behavior when JWE decryption setup fails
**Severity**: High
**Repository**: venafi/vmware-avi-connector

The `addPayloadEncryptionMiddleware` function would silently fail if the payload encryption key couldn't be loaded or parsed, logging errors but allowing the server to continue accepting requests without encryption validation. This created a fail-open scenario where invalid or missing encryption keys would result in unprotected endpoints.

## Remediation

Modified `internal/handler/web/web.go`:

1. **Changed function signature**: `addPayloadEncryptionMiddleware` now returns `error` instead of being void
2. **Propagate key loading errors**: Return errors immediately when:
   - Private key file cannot be read
   - PEM decoding fails  
   - PKCS1 private key parsing fails
3. **Enforce fail-closed**: `RegisterHandlers` now checks the middleware setup error and returns it, preventing the server from starting if payload encryption cannot be properly configured

This ensures that any failure in setting up the encryption middleware will cause the application to fail during initialization rather than silently accepting unencrypted requests.

## Verification

The fix ensures fail-closed behavior by:
- Returning errors from `addPayloadEncryptionMiddleware` when key setup fails
- Checking and propagating the error in `RegisterHandlers`
- Preventing server startup if middleware cannot be properly configured

Note: Build/test failures are due to environment configuration issues (missing GOROOT), not related to this security fix.